### PR TITLE
Made tcltk workable

### DIFF
--- a/r.rb
+++ b/r.rb
@@ -22,7 +22,7 @@ class R < Formula
   depends_on "sethrfore/r-srf/cairo" => :optional # SRF - Cairo must be build with with X11 support. Use brew install sethrfore/r-srf/cairo
   depends_on "icu4c" => :optional
   # depends_on "pango" => :optional
-
+  #depends_on "tcl-tk" 
   # needed to preserve executable permissions on files without shebangs
   skip_clean "lib/R/bin"
 
@@ -39,22 +39,44 @@ class R < Formula
       ENV["ac_cv_have_decl_clock_gettime"] = "no"
     end
 
+    ## 
+    if MacOS.version == "10.15" # At least these changes are needed for catalina
+      ### YT Set up some  environment variables and over-write some variables defined in tclConfig.sh and tkConfig.sh 
+      ENV["TCL_INCLUDE_SPEC"] = "-I#{MacOS.sdk_path}/System/Library/Frameworks/Tcl.framework/Versions/8.5/Headers"
+      ENV["TK_INCLUDE_SPEC"] = "-I#{MacOS.sdk_path}/System/Library/Frameworks/Tk.framework/Versions/8.5/Headers"
+      ENV["TCLTK_CPPFLAGS"] = "-I#{MacOS.sdk_path}/System/Library/Frameworks/Tcl.framework/Versions/8.5/Headers \
+                -I#{MacOS.sdk_path}/System/Library/Frameworks/Tk.framework/Versions/8.5/Headers"
+      ENV["TCLTK_LIBS"] = "-F#{MacOS.sdk_path}/System/Library/Frameworks -framework Tk \
+               -F#{MacOS.sdk_path}/System/Library/Frameworks -framework Tcl"
+      #ENV["TK_LIB_SPEC"] = "-F#{MacOS.sdk_path}/System/Library/Frameworks -framework Tk"  # YT This does not work
+      #ENV["TCL_LIB_SPEC"] = "-F#{MacOS.sdk_path}/System/Library/Frameworks -framework Tcl" # YT This does not work
+    end
+
     ## SRF - Add cairo capability (comment/uncomment corresponding cairo args below as necessary)
     # Fix cairo detection with Quartz-only cairo
     # inreplace ["configure", "m4/cairo.m4"], "cairo-xlib.h", "cairo.h"
-
+    #tcl_lib = Formula["tcl-tk"].opt_lib # YT If homebrew's tcl-tk is to be used, this line should be uncommented
     args = [
       "--prefix=#{prefix}",
       "--enable-memory-profiling",
       "--with-x", # SRF - Add X11 support (comment --without-x). Necessary for tcl-tk support.
+      #"--without-x",  # YT If Homebrew's tcl-tk is to be used, '--with-x' cause an error 
       "--with-aqua",
       "--with-lapack",
       "--enable-R-shlib",
       "SED=/usr/bin/sed", # don't remember Homebrew's sed shim
       "--with-tcltk", # SRF - Add tcl-tk support.
-      "--with-tcl-config=/System/Library/Frameworks/Tcl.framework/tclConfig.sh", # SRF - Point to system tcl config file (requires Command Line tools to be installed).
-      "--with-tk-config=/System/Library/Frameworks/Tk.framework/tkConfig.sh" # SRF - Point to system tk config file (requires Command Line tools to be installed).
+      ## "--with-tcl-config=/System/Library/Frameworks/Tcl.framework/tclConfig.sh", # SRF - Point to system tcl config file (requires Command Line tools to be installed).
+      "--with-tcl-config=#{MacOS.sdk_path}/System/Library/Frameworks/Tcl.framework/tclConfig.sh",
+      #"--with-tcl-config=#{tcl_lib}/tclConfig.sh", # YT If homebrew's tcl-tk is to be used, this line should be uncommented
+      ## "--with-tk-config=/System/Library/Frameworks/Tk.framework/tkConfig.sh" # SRF - Point to system tk config file (requires Command Line tools to be installed).
+      #"--with-tk-config=#{tcl_lib}/tkConfig.sh" # YT If homebrew's tcl-tk is to be used, this line should be uncommented
+      "--with-tk-config=#{MacOS.sdk_path}/System/Library/Frameworks/Tk.framework/tkConfig.sh"
+      
     ]
+    
+    ### Tests for tcltk
+    #ENV["TCL_INCLUDE_SPEC"] = "-iwithsysroot #{MacOS.sdk_path}/System/Library/Frameworks/Tk.framework/Versions/8.5/Headers"
 
     if build.with? "openblas"
       args << "--with-blas=-L#{Formula["openblas"].opt_lib} -lopenblas"


### PR DESCRIPTION
As an alternative approach to the dev-tcl branch, I defined two configure variables
TCLTK_CPPFLAGS adn TCLTK_LIBS, that are mentioned  in [A.2.1 Tcl/Tk of R Installation and Administration](https://cran.r-project.org/doc/manuals/R-admin.html) in the formula. In addition, 
TCL_INCLUDE_SPEC, TK_INCLUDE_SPEC are redefined in formula to overwrite values in tclConfig.sh or tkConfig.sh. for Catalina

Values of --with-tcl-config and --with-tk-config are modified to use MacOS.sdk_path defined by homebrew.

These changes works in my Mac (10.15.4) at home. 