### PR TITLE
Add MacOS 11.0 to use path for tcl-tk from SDK

### DIFF
--- a/r.rb
+++ b/r.rb
@@ -41,7 +41,7 @@ class R < Formula
     end
 
     ## YT - enable tcl-tk support using system headers
-    if MacOS.version == "10.15" # At least these changes are needed for catalina
+    if MacOS.version == "10.15" || MacOS.version == "11.0" # This seems to work for Catalina and Big Sur
       ## YT - Set up some  environment variables and over-write some variables defined in tclConfig.sh and tkConfig.sh 
       ENV["TCL_INCLUDE_SPEC"] = "-I#{MacOS.sdk_path}/System/Library/Frameworks/Tcl.framework/Versions/8.5/Headers"
       ENV["TK_INCLUDE_SPEC"] = "-I#{MacOS.sdk_path}/System/Library/Frameworks/Tk.framework/Versions/8.5/Headers"


### PR DESCRIPTION
MacOS.version == "11.0" is added in addition to MacOS.version == "10.15" to the condition to set path to system headers for tcl-tk.
Now they are used either OS version is Catalina or Big Sur.
It seems that this change is working for  Big Sur on Intel platform.
I doubt, this work on Apple silicon paltform.