### PR TITLE
update to R-4.1.1

### DIFF
--- a/r.rb
+++ b/r.rb
@@ -1,10 +1,10 @@
 class R < Formula
   desc "Software environment for statistical computing"
   homepage "https://www.r-project.org/"
-  url "https://cran.r-project.org/src/base/R-4/R-4.1.0.tar.gz"
-  sha256 "e8e68959d7282ca147360fc9644ada9bd161bab781bab14d33b8999a95182781"
+  url "https://cran.r-project.org/src/base/R-4/R-4.1.1.tar.gz"
+  sha256 "515e03265752257d0b7036f380f82e42b46ed8473f54f25c7b67ed25bbbdd364"
   license "GPL-2.0-or-later"
-  revision 2
+  #revision 2
 
   depends_on "pkg-config" => :build
   depends_on "fontconfig"


### PR DESCRIPTION
Update R version to 4.1.1

Revision was removed from r.rb for this pull request.
This is because homebrew interprets,
4.1.1 is newer than 4.1.0_2
If this formula is updated without changing the software (R) version,
we can use Revision to tell homebrew the revised formula is newer than
original 
